### PR TITLE
DEVOPS-725: Print less logs on startup.

### DIFF
--- a/lib/rake-tasks-docker/services.rb
+++ b/lib/rake-tasks-docker/services.rb
@@ -61,8 +61,8 @@ module RakeTasksDocker
       Process.spawn 'docker-compose', 'up', '-d', *@services
     end
 
-    def logs
-      Process.spawn 'docker-compose', 'logs', '-f', *@services
+    def logs(tail_amount = 50)
+      Process.spawn 'docker-compose', 'logs', '-f', '--tail=' + tail_amount.to_s, *@services
     end
 
     def stop

--- a/lib/rake-tasks-docker/version.rb
+++ b/lib/rake-tasks-docker/version.rb
@@ -1,3 +1,3 @@
 module RakeTasksDocker
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
If a container already exists, `docker-compose logs -f` prints all
logs since the container booted up for the first time.
Especially if you are resuming a project, this can take several seconds to
output all of the container logs.

Would prefer to use --since but that only exists on `docker logs`